### PR TITLE
feat: upgrade syn to 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ description = "Support for trait alias feature on stable Rust."
 proc-macro = true
 
 [dependencies]
-syn = "1.0"
+syn = "2.0"
 quote = "1.0"
 proc-macro2 = "1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "trait-set"
 version = "0.3.0"
 authors = ["Igor Aleksanov <popzxc@yandex.ru>"]
 edition = "2018"
+rust-version = "1.56"
 repository = "https://github.com/popzxc/trait-set"
 documentation = "https://docs.rs/trait-set"
 readme = "README.md"


### PR DESCRIPTION
Here's just the upgrade to syn 2.0. Tested on MSRV and Rust 1.91.1 with syn 2.0.0 and latest.